### PR TITLE
XParseGeometry will always be needed for Windows, no need for cmake to f...

### DIFF
--- a/freeglut/freeglut/src/fg_init.c
+++ b/freeglut/freeglut/src/fg_init.c
@@ -317,7 +317,7 @@ void fgDeinitialize( void )
 
 
 /* -- INTERFACE FUNCTIONS -------------------------------------------------- */
-#if defined(NEED_XPARSEGEOMETRY_IMPL)
+#if defined(NEED_XPARSEGEOMETRY_IMPL) || defined(TARGET_HOST_MS_WINDOWS)
 #   include "util/xparsegeometry_repl.h"
 #endif
 


### PR DESCRIPTION
I see that cmake is now being used to auto-detect things such as this.  However, for non-cmake builds of FreeGLUT needing to needlessly manage NEED_XPARSEGEOMETRY_IMPL seems a bit unreasonable...  Is there  a happy middle ground for this?