### PR TITLE
Externalized + centralized (some) types visible in freeglut_std.h

### DIFF
--- a/freeglut/freeglut/CMakeLists.txt
+++ b/freeglut/freeglut/CMakeLists.txt
@@ -49,6 +49,7 @@ SET(FREEGLUT_HEADERS
     include/GL/freeglut.h
     include/GL/freeglut_ext.h
     include/GL/freeglut_std.h
+    include/GL/freeglut_types.h
     include/GL/glut.h
 )
 SET(FREEGLUT_SRCS

--- a/freeglut/freeglut/include/GL/freeglut_ext.h
+++ b/freeglut/freeglut/include/GL/freeglut_ext.h
@@ -145,12 +145,12 @@ FGAPI void    FGAPIENTRY glutSetMenuFont( int menuID, void* font );
 /*
  * Window-specific callback functions, see fg_callbacks.c
  */
-FGAPI void    FGAPIENTRY glutMouseWheelFunc( void (* callback)( int, int, int, int ) );
-FGAPI void    FGAPIENTRY glutPositionFunc( void (* callback)( int, int ) );
-FGAPI void    FGAPIENTRY glutCloseFunc( void (* callback)( void ) );
-FGAPI void    FGAPIENTRY glutWMCloseFunc( void (* callback)( void ) );
+FGAPI void    FGAPIENTRY glutMouseWheelFunc( FGCBMouseWheel callback );
+FGAPI void    FGAPIENTRY glutPositionFunc( FGCBPosition callback );
+FGAPI void    FGAPIENTRY glutCloseFunc( FGCBClose callback );
+FGAPI void    FGAPIENTRY glutWMCloseFunc( FGCBWMClose callback );
 /* And also a destruction callback for menus */
-FGAPI void    FGAPIENTRY glutMenuDestroyFunc( void (* callback)( void ) );
+FGAPI void    FGAPIENTRY glutMenuDestroyFunc( FGCBDestroy callback );
 
 /*
  * State setting and retrieval functions, see fg_state.c
@@ -204,10 +204,10 @@ FGAPI GLUTproc FGAPIENTRY glutGetProcAddress( const char *procName );
 
 /* TODO: add device_id parameter,
    cf. http://sourceforge.net/mailarchive/forum.php?thread_name=20120518071314.GA28061%40perso.beuc.net&forum_name=freeglut-developer */
-FGAPI void FGAPIENTRY glutMultiEntryFunc( void (* callback)( int, int ) );
-FGAPI void FGAPIENTRY glutMultiButtonFunc( void (* callback)( int, int, int, int, int ) );
-FGAPI void FGAPIENTRY glutMultiMotionFunc( void (* callback)( int, int, int ) );
-FGAPI void FGAPIENTRY glutMultiPassiveFunc( void (* callback)( int, int, int ) );
+FGAPI void FGAPIENTRY glutMultiEntryFunc( FGCBMultiEntry callback );
+FGAPI void FGAPIENTRY glutMultiButtonFunc( FGCBMultiButton callback );
+FGAPI void FGAPIENTRY glutMultiMotionFunc( FGCBMultiMotion callback );
+FGAPI void FGAPIENTRY glutMultiPassiveFunc( FGCBMultiPassive callback );
 
 /*
  * Joystick functions, see fg_joystick.c
@@ -240,8 +240,8 @@ void    glutJoystickGetCenter( int ident, float *axes );
 FGAPI void    FGAPIENTRY glutInitContextVersion( int majorVersion, int minorVersion );
 FGAPI void    FGAPIENTRY glutInitContextFlags( int flags );
 FGAPI void    FGAPIENTRY glutInitContextProfile( int profile );
-FGAPI void    FGAPIENTRY glutInitErrorFunc( void (* callback)( const char *fmt, va_list ap ) );
-FGAPI void    FGAPIENTRY glutInitWarningFunc( void (* callback)( const char *fmt, va_list ap ) );
+FGAPI void    FGAPIENTRY glutInitErrorFunc( FGError callback );
+FGAPI void    FGAPIENTRY glutInitWarningFunc( FGWarning callback );
 
 /* OpenGL >= 2.0 support */
 FGAPI void    FGAPIENTRY glutSetVertexAttribCoord3(GLint attrib);
@@ -249,8 +249,8 @@ FGAPI void    FGAPIENTRY glutSetVertexAttribNormal(GLint attrib);
 FGAPI void    FGAPIENTRY glutSetVertexAttribTexCoord2(GLint attrib);
 
 /* Mobile platforms lifecycle */
-FGAPI void    FGAPIENTRY glutInitContextFunc(void (* callback)());
-FGAPI void    FGAPIENTRY glutAppStatusFunc(void (* callback)(int));
+FGAPI void    FGAPIENTRY glutInitContextFunc( FGCBInitContext callback );
+FGAPI void    FGAPIENTRY glutAppStatusFunc( FGCBAppStatus callback );
 /* state flags that can be passed to callback set by glutAppStatusFunc */
 #define GLUT_APPSTATUS_PAUSE                0x0001
 #define GLUT_APPSTATUS_RESUME               0x0002

--- a/freeglut/freeglut/include/GL/freeglut_std.h
+++ b/freeglut/freeglut/include/GL/freeglut_std.h
@@ -144,6 +144,9 @@
 #   include <GL/glu.h>
 #endif
 
+// freeglut types visible in this header
+#include "freeglut_types.h"
+
 /*
  * GLUT API macro definitions -- the special key codes:
  */
@@ -467,7 +470,7 @@ FGAPI void    FGAPIENTRY glutHideOverlay( void );
 /*
  * Menu stuff, see fg_menu.c
  */
-FGAPI int     FGAPIENTRY glutCreateMenu( void (* callback)( int menu ) );
+FGAPI int     FGAPIENTRY glutCreateMenu( FGCBMenu callback );
 FGAPI void    FGAPIENTRY glutDestroyMenu( int menu );
 FGAPI int     FGAPIENTRY glutGetMenu( void );
 FGAPI void    FGAPIENTRY glutSetMenu( int menu );
@@ -482,37 +485,37 @@ FGAPI void    FGAPIENTRY glutDetachMenu( int button );
 /*
  * Global callback functions, see fg_callbacks.c
  */
-FGAPI void    FGAPIENTRY glutTimerFunc( unsigned int time, void (* callback)( int ), int value );
-FGAPI void    FGAPIENTRY glutIdleFunc( void (* callback)( void ) );
+FGAPI void    FGAPIENTRY glutTimerFunc( unsigned int time, FGCBTimer callback, int value );
+FGAPI void    FGAPIENTRY glutIdleFunc( FGCBIdle callback );
 
 /*
  * Window-specific callback functions, see fg_callbacks.c
  */
-FGAPI void    FGAPIENTRY glutKeyboardFunc( void (* callback)( unsigned char, int, int ) );
-FGAPI void    FGAPIENTRY glutSpecialFunc( void (* callback)( int, int, int ) );
-FGAPI void    FGAPIENTRY glutReshapeFunc( void (* callback)( int, int ) );
-FGAPI void    FGAPIENTRY glutVisibilityFunc( void (* callback)( int ) );
-FGAPI void    FGAPIENTRY glutDisplayFunc( void (* callback)( void ) );
-FGAPI void    FGAPIENTRY glutMouseFunc( void (* callback)( int, int, int, int ) );
-FGAPI void    FGAPIENTRY glutMotionFunc( void (* callback)( int, int ) );
-FGAPI void    FGAPIENTRY glutPassiveMotionFunc( void (* callback)( int, int ) );
-FGAPI void    FGAPIENTRY glutEntryFunc( void (* callback)( int ) );
+FGAPI void    FGAPIENTRY glutKeyboardFunc( FGCBKeyboard callback );
+FGAPI void    FGAPIENTRY glutSpecialFunc( FGCBSpecial callback );
+FGAPI void    FGAPIENTRY glutReshapeFunc(FGCBReshape callback );
+FGAPI void    FGAPIENTRY glutVisibilityFunc( FGCBVisibility callback );
+FGAPI void    FGAPIENTRY glutDisplayFunc( FGCBDisplay callback );
+FGAPI void    FGAPIENTRY glutMouseFunc( FGCBMouse callback );
+FGAPI void    FGAPIENTRY glutMotionFunc( FGCBMotion callback );
+FGAPI void    FGAPIENTRY glutPassiveMotionFunc( FGCBPassive callback );
+FGAPI void    FGAPIENTRY glutEntryFunc( FGCBEntry callback );
 
-FGAPI void    FGAPIENTRY glutKeyboardUpFunc( void (* callback)( unsigned char, int, int ) );
-FGAPI void    FGAPIENTRY glutSpecialUpFunc( void (* callback)( int, int, int ) );
-FGAPI void    FGAPIENTRY glutJoystickFunc( void (* callback)( unsigned int, int, int, int ), int pollInterval );
-FGAPI void    FGAPIENTRY glutMenuStateFunc( void (* callback)( int ) );
-FGAPI void    FGAPIENTRY glutMenuStatusFunc( void (* callback)( int, int, int ) );
-FGAPI void    FGAPIENTRY glutOverlayDisplayFunc( void (* callback)( void ) );
-FGAPI void    FGAPIENTRY glutWindowStatusFunc( void (* callback)( int ) );
+FGAPI void    FGAPIENTRY glutKeyboardUpFunc( FGCBKeyboardUp callback );
+FGAPI void    FGAPIENTRY glutSpecialUpFunc( FGCBSpecialUp callback );
+FGAPI void    FGAPIENTRY glutJoystickFunc( FGCBJoystick callback, int pollInterval );
+FGAPI void    FGAPIENTRY glutMenuStateFunc( FGCBMenuState callback );
+FGAPI void    FGAPIENTRY glutMenuStatusFunc( FGCBMenuStatus callback );
+FGAPI void    FGAPIENTRY glutOverlayDisplayFunc( FGCBOverlayDisplay callback );
+FGAPI void    FGAPIENTRY glutWindowStatusFunc( FGCBWindowStatus callback );
 
-FGAPI void    FGAPIENTRY glutSpaceballMotionFunc( void (* callback)( int, int, int ) );
-FGAPI void    FGAPIENTRY glutSpaceballRotateFunc( void (* callback)( int, int, int ) );
-FGAPI void    FGAPIENTRY glutSpaceballButtonFunc( void (* callback)( int, int ) );
-FGAPI void    FGAPIENTRY glutButtonBoxFunc( void (* callback)( int, int ) );
-FGAPI void    FGAPIENTRY glutDialsFunc( void (* callback)( int, int ) );
-FGAPI void    FGAPIENTRY glutTabletMotionFunc( void (* callback)( int, int ) );
-FGAPI void    FGAPIENTRY glutTabletButtonFunc( void (* callback)( int, int, int, int ) );
+FGAPI void    FGAPIENTRY glutSpaceballMotionFunc( FGCBSpaceMotion callback );
+FGAPI void    FGAPIENTRY glutSpaceballRotateFunc( FGCBSpaceRotation callback );
+FGAPI void    FGAPIENTRY glutSpaceballButtonFunc( FGCBSpaceButton callback );
+FGAPI void    FGAPIENTRY glutButtonBoxFunc( FGCBButtonBox callback );
+FGAPI void    FGAPIENTRY glutDialsFunc( FGCBDials callback );
+FGAPI void    FGAPIENTRY glutTabletMotionFunc( FGCBTabletMotion callback );
+FGAPI void    FGAPIENTRY glutTabletButtonFunc( FGCBTabletButton callback );
 
 /*
  * State setting and retrieval functions, see fg_state.c

--- a/freeglut/freeglut/include/GL/freeglut_types.h
+++ b/freeglut/freeglut/include/GL/freeglut_types.h
@@ -62,6 +62,8 @@ typedef void(*FGCBButtonBox)(int, int);
 typedef void(*FGCBTabletMotion)(int, int);
 typedef void(*FGCBTabletButton)(int, int, int, int);
 typedef void(*FGCBDestroy)(void);    /* Used for both window and menu destroy callbacks */
+typedef void(*FGCBClose)(void);
+typedef void(*FGCBWMClose)(void);
 
 typedef void(*FGCBMultiEntry)(int, int);
 typedef void(*FGCBMultiButton)(int, int, int, int, int);

--- a/freeglut/freeglut/include/GL/freeglut_types.h
+++ b/freeglut/freeglut/include/GL/freeglut_types.h
@@ -1,0 +1,89 @@
+/*
+* freeglut_types.h
+*
+* The freeglut library global typedefs.
+* 
+* Ideally *every* type that is visible via freeglut_std.h
+* should be moved here so if a developer changes the underlying type
+* client code can also take advantage of using the new type w/o
+* changing its code. For now this covers callback types only.
+*
+* Copyright (c) 1999-2000 Pawel W. Olszta. All Rights Reserved.
+* Written by Pawel W. Olszta, <olszta@sourceforge.net>
+* Creation date: Thu Dec 2 1999
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+* PAWEL W. OLSZTA BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+* IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+* CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef  FREEGLUT_TYPES_H
+#define  FREEGLUT_TYPES_H
+
+#include <string.h>
+
+/* -- GLOBAL TYPE DEFINITIONS ---------------------------------------------- */
+
+/* Freeglut callbacks type definitions */
+typedef void(*FGCBDisplay)(void);
+typedef void(*FGCBReshape)(int, int);
+typedef void(*FGCBPosition)(int, int);
+typedef void(*FGCBVisibility)(int);
+typedef void(*FGCBKeyboard)(unsigned char, int, int);
+typedef void(*FGCBKeyboardUp)(unsigned char, int, int);
+typedef void(*FGCBSpecial)(int, int, int);
+typedef void(*FGCBSpecialUp)(int, int, int);
+typedef void(*FGCBMouse)(int, int, int, int);
+typedef void(*FGCBMouseWheel)(int, int, int, int);
+typedef void(*FGCBMotion)(int, int);
+typedef void(*FGCBPassive)(int, int);
+typedef void(*FGCBEntry)(int);
+typedef void(*FGCBWindowStatus)(int);
+typedef void(*FGCBJoystick)(unsigned int, int, int, int);
+typedef void(*FGCBOverlayDisplay)(void);
+typedef void(*FGCBSpaceMotion)(int, int, int);
+typedef void(*FGCBSpaceRotation)(int, int, int);
+typedef void(*FGCBSpaceButton)(int, int);
+typedef void(*FGCBDials)(int, int);
+typedef void(*FGCBButtonBox)(int, int);
+typedef void(*FGCBTabletMotion)(int, int);
+typedef void(*FGCBTabletButton)(int, int, int, int);
+typedef void(*FGCBDestroy)(void);    /* Used for both window and menu destroy callbacks */
+
+typedef void(*FGCBMultiEntry)(int, int);
+typedef void(*FGCBMultiButton)(int, int, int, int, int);
+typedef void(*FGCBMultiMotion)(int, int, int);
+typedef void(*FGCBMultiPassive)(int, int, int);
+
+typedef void(*FGCBInitContext)();
+typedef void(*FGCBAppStatus)(int);
+
+/* The global callbacks type definitions */
+typedef void(*FGCBIdle)(void);
+typedef void(*FGCBTimer)(int);
+typedef void(*FGCBMenuState)(int);
+typedef void(*FGCBMenuStatus)(int, int, int);
+
+/* The callback used when creating/using menus */
+typedef void(*FGCBMenu)(int);
+
+/* The FreeGLUT error/warning handler type definition */
+typedef void(*FGError) (const char *fmt, va_list ap);
+typedef void(*FGWarning) (const char *fmt, va_list ap);
+
+#endif /* FREEGLUT_TYPES_H */
+
+/*** END OF FILE ***/

--- a/freeglut/freeglut/src/fg_internal.h
+++ b/freeglut/freeglut/src/fg_internal.h
@@ -203,53 +203,7 @@
 
 
 /* -- GLOBAL TYPE DEFINITIONS ---------------------------------------------- */
-
-/* Freeglut callbacks type definitions */
-typedef void (* FGCBDisplay       )( void );
-typedef void (* FGCBReshape       )( int, int );
-typedef void (* FGCBPosition      )( int, int );
-typedef void (* FGCBVisibility    )( int );
-typedef void (* FGCBKeyboard      )( unsigned char, int, int );
-typedef void (* FGCBKeyboardUp    )( unsigned char, int, int );
-typedef void (* FGCBSpecial       )( int, int, int );
-typedef void (* FGCBSpecialUp     )( int, int, int );
-typedef void (* FGCBMouse         )( int, int, int, int );
-typedef void (* FGCBMouseWheel    )( int, int, int, int );
-typedef void (* FGCBMotion        )( int, int );
-typedef void (* FGCBPassive       )( int, int );
-typedef void (* FGCBEntry         )( int );
-typedef void (* FGCBWindowStatus  )( int );
-typedef void (* FGCBJoystick      )( unsigned int, int, int, int );
-typedef void (* FGCBOverlayDisplay)( void );
-typedef void (* FGCBSpaceMotion   )( int, int, int );
-typedef void (* FGCBSpaceRotation )( int, int, int );
-typedef void (* FGCBSpaceButton   )( int, int );
-typedef void (* FGCBDials         )( int, int );
-typedef void (* FGCBButtonBox     )( int, int );
-typedef void (* FGCBTabletMotion  )( int, int );
-typedef void (* FGCBTabletButton  )( int, int, int, int );
-typedef void (* FGCBDestroy       )( void );    /* Used for both window and menu destroy callbacks */
-
-typedef void (* FGCBMultiEntry   )( int, int );
-typedef void (* FGCBMultiButton  )( int, int, int, int, int );
-typedef void (* FGCBMultiMotion  )( int, int, int );
-typedef void (* FGCBMultiPassive )( int, int, int );
-
-typedef void (* FGCBInitContext)();
-typedef void (* FGCBAppStatus)(int);
-
-/* The global callbacks type definitions */
-typedef void (* FGCBIdle          )( void );
-typedef void (* FGCBTimer         )( int );
-typedef void (* FGCBMenuState     )( int );
-typedef void (* FGCBMenuStatus    )( int, int, int );
-
-/* The callback used when creating/using menus */
-typedef void (* FGCBMenu          )( int );
-
-/* The FreeGLUT error/warning handler type definition */
-typedef void (* FGError           ) ( const char *fmt, va_list ap);
-typedef void (* FGWarning         ) ( const char *fmt, va_list ap);
+#include <Gl\freeglut_types.h>
 
 
 /* A list structure */


### PR DESCRIPTION
Ok, first off, let me start by the fact that C function pointers are extremely pain to make state-aware (well even `glutSetWindowData` is not enough in some cases where callback functions need to be allocated dynamically - imagine being embedded in a project where callbacks are coming from a Lua host, therefore they are not known at the compile time). I wanted not to change the type of the callbacks but I have to.

This is extremely important to C++ users and folks who try to embed Freeglut in their C++ related projects. There needs to be flexibility to change datatypes without breaking the underlying code. 

As a rough example, if I want to change `void(*)(void)` to `std::function<void()>`, everything should still function perfectly fine in theory. This particular example also needs an `allocate` function to initialize the Freeglut's state struct. But you got the idea.

I attempted to change the callback types but everything in Freeglut's main include file (`freeglut_std.h`) is strictly typed in place instead of having a centralized place. So I am proposing the idea of centralizing `typedef`s that are visible via `freeglut_std.h` with this pull request.