### PR TITLE
Fix compilation on Linux.

### DIFF
--- a/freeglut/freeglut/src/fg_spaceball.c
+++ b/freeglut/freeglut/src/fg_spaceball.c
@@ -11,7 +11,7 @@
 #include <GL/freeglut.h>
 #include "fg_internal.h"
 
-#if(_WIN32_WINNT >= 0x0501)
+#if( !_WIN32 || _WIN32_WINNT >= 0x0501)
 
 /* -- PRIVATE FUNCTIONS --------------------------------------------------- */
 


### PR DESCRIPTION
Commit ce15044f7362943aee7d465bf20310ba02991dae introduced an error
"undefined reference to `sball_initialized'" on non-Windows operating
systems.