### PR TITLE
Fixed freeglut.pdb install for builds with MSVC compiler and NMake.

### DIFF
--- a/freeglut/freeglut/CMakeLists.txt
+++ b/freeglut/freeglut/CMakeLists.txt
@@ -484,10 +484,17 @@ IF(FREEGLUT_BUILD_SHARED_LIBS)
             INCLUDES DESTINATION include
     )
     IF(INSTALL_PDB)
-        INSTALL(FILES ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Debug/freeglut${CMAKE_DEBUG_POSTFIX}.pdb
-            DESTINATION bin
-            CONFIGURATIONS Debug
-            COMPONENT Devel)
+        IF(CMAKE_GENERATOR MATCHES "^Visual Studio")
+            INSTALL(FILES ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Debug/freeglut${CMAKE_DEBUG_POSTFIX}.pdb
+                DESTINATION bin
+                CONFIGURATIONS Debug
+                COMPONENT Devel)
+        ELSE()
+            INSTALL(FILES ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/freeglut${CMAKE_DEBUG_POSTFIX}.pdb
+                DESTINATION bin
+                CONFIGURATIONS Debug
+                COMPONENT Devel)
+        ENDIF()
     ENDIF()
 ENDIF()
 IF(FREEGLUT_BUILD_STATIC_LIBS)


### PR DESCRIPTION
The CMake variable "MSVC" indicates that the Visual Studio compiler is
used but  when using that compiler and the "NMake Makefiles JOM" build
generator the *.pdb is wasn't output in a "Debug" directory.