### PR TITLE
Use <sys/joystick.h> on netbsd, too.

### DIFF
--- a/freeglut/freeglut/src/wayland/fg_internal_wl.h
+++ b/freeglut/freeglut/src/wayland/fg_internal_wl.h
@@ -105,18 +105,7 @@ struct tagSFG_PlatformWindowState
 /* XXX The below hack is done until freeglut's autoconf is updated. */
 #        define HAVE_USB_JS    1
 
-#        if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
-#            include <sys/joystick.h>
-#        else
-/*
- * XXX NetBSD/amd64 systems may find that they have to steal the
- * XXX /usr/include/machine/joystick.h from a NetBSD/i386 system.
- * XXX I cannot comment whether that works for the interface, but
- * XXX it lets you compile...(^&  I do not think that we can do away
- * XXX with this header.
- */
-#            include <machine/joystick.h>         /* For analog joysticks */
-#        endif
+#        include <sys/joystick.h>
 #        define JS_DATA_TYPE joystick
 #        define JS_RETURN (sizeof(struct JS_DATA_TYPE))
 #    endif

--- a/freeglut/freeglut/src/wayland/fg_internal_wl.h
+++ b/freeglut/freeglut/src/wayland/fg_internal_wl.h
@@ -102,7 +102,6 @@ struct tagSFG_PlatformWindowState
 #include <string.h>
 
 #    if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__)
-/* XXX The below hack is done until freeglut's autoconf is updated. */
 #        define HAVE_USB_JS    1
 
 #        include <sys/joystick.h>

--- a/freeglut/freeglut/src/x11/fg_internal_x11.h
+++ b/freeglut/freeglut/src/x11/fg_internal_x11.h
@@ -138,19 +138,7 @@ struct tagSFG_PlatformWindowState
 #    if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__)
 /* XXX The below hack is done until freeglut's autoconf is updated. */
 #        define HAVE_USB_JS    1
-
-#        if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
-#            include <sys/joystick.h>
-#        else
-/*
- * XXX NetBSD/amd64 systems may find that they have to steal the
- * XXX /usr/include/machine/joystick.h from a NetBSD/i386 system.
- * XXX I cannot comment whether that works for the interface, but
- * XXX it lets you compile...(^&  I do not think that we can do away
- * XXX with this header.
- */
-#            include <machine/joystick.h>         /* For analog joysticks */
-#        endif
+#        include <sys/joystick.h>
 #        define JS_DATA_TYPE joystick
 #        define JS_RETURN (sizeof(struct JS_DATA_TYPE))
 #    endif

--- a/freeglut/freeglut/src/x11/fg_internal_x11.h
+++ b/freeglut/freeglut/src/x11/fg_internal_x11.h
@@ -136,7 +136,6 @@ struct tagSFG_PlatformWindowState
 #include <string.h>
 
 #    if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__)
-/* XXX The below hack is done until freeglut's autoconf is updated. */
 #        define HAVE_USB_JS    1
 #        include <sys/joystick.h>
 #        define JS_DATA_TYPE joystick


### PR DESCRIPTION
<machine/joystick.h> is a compatibility header that only includes
<sys/joystick.h>, and wasn't added to newer architectures.

This helps the build on netbsd/aarch64.